### PR TITLE
Run build.sh using bash

### DIFF
--- a/sources/build.sh
+++ b/sources/build.sh
@@ -1,10 +1,16 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 # Go the sources directory to run commands
-SOURCE="${BASH_SOURCE[0]}"
-DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
-cd $DIR
+if [ -z "$SOURCE" -a "${#BASH_SOURCE}" -gt 0 ]
+then
+	SOURCE="${BASH_SOURCE[0]}"
+fi
+if [ -n "$SOURCE" ]
+then
+	DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+	cd $DIR
+fi
 echo $(pwd)
 
 echo "Generating Static fonts"


### PR DESCRIPTION
The `#!` line invokes a shell that might not always be bash.  It doesn't
work if it isn't because it reads a bash-specific variable.

The effect of this change is to require bash.  If your system runs a
different shell for `/bin/sh`, but it has bash, then this is probably
what you want.

For systems that do not have bash, this might not be ideal.  For that,
the `#!` line could be reverted.  Those systems would then run from the
current directory, or could set `$SOURCE` directly.  The second change
ensures that is possible.

So either change would be an improvement; both is probably redundant,
but it's harmless.